### PR TITLE
silent logs before connected

### DIFF
--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -63,8 +63,8 @@ impl Client {
         }
 
         unsafe {
-            jack_sys::jack_set_error_function(Some(error_handler));
-            jack_sys::jack_set_info_function(Some(info_handler));
+            jack_sys::jack_set_error_function(Some(silent_handler));
+            jack_sys::jack_set_info_function(Some(silent_handler));
         }
         sleep_on_test();
         let mut status_bits = 0;
@@ -89,6 +89,11 @@ impl Client {
         if client.is_null() {
             Err(Error::ClientError(status))
         } else {
+            unsafe {
+                jack_sys::jack_set_error_function(Some(error_handler));
+                jack_sys::jack_set_info_function(Some(info_handler));
+            }
+            sleep_on_test();
             Ok((Client(client, Arc::default(), None), status))
         }
     }
@@ -803,4 +808,8 @@ unsafe extern "C" fn info_handler(msg: *const libc::c_char) {
         Ok(msg) => log::info!("{}", msg),
         Err(err) => log::error!("failed to parse JACK error: {:?}", err),
     }
+}
+
+unsafe extern "C" fn silent_handler(_msg: *const libc::c_char) {
+    //silent
 }


### PR DESCRIPTION
When starting client to jack server and connection fails, the error logs are printed to console with no way to silence it.
The returned result from client connection is enough to programatically write something regarding the fail, if desired. Otherwise this should not print anything to console. 
